### PR TITLE
spa が原因でモバイルスクロールが動かないか調べてみる

### DIFF
--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -10,7 +10,9 @@ const config: QuartzConfig = {
   configuration: {
     pageTitle: "ganyariya note",
     pageTitleSuffix: "",
-    enableSPA: true,
+    // https://github.com/jackyzha0/quartz/issues/1918
+    // 試してみる
+    enableSPA: false,
     enablePopovers: true,
     analytics: {
       provider: "plausible",


### PR DESCRIPTION
モバイルでスクロールができない
その原因を調べる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Disabled Single Page Application (SPA) mode in the site configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->