### PR TITLE
Google Analytics ID を追加する

### DIFF
--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -1,6 +1,8 @@
 import { QuartzConfig } from "./quartz/cfg"
 import * as Plugin from "./quartz/plugins"
 
+const GOOGLE_ANALYTICS_ID = process.env.GOOGLE_ANALYTICS_ID || ""
+
 /**
  * Quartz 4 Configuration
  *
@@ -14,8 +16,10 @@ const config: QuartzConfig = {
     // 試してみる
     enableSPA: false,
     enablePopovers: true,
+    // https://quartz.jzhao.xyz/configuration#general-configuration
     analytics: {
-      provider: "plausible",
+      provider: "google",
+      tagId: GOOGLE_ANALYTICS_ID,
     },
     locale: "ja-JP",
     baseUrl: "note.ganyariya.dev",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated analytics configuration to use Google Analytics instead of Plausible.
  - Added support for specifying the Google Analytics tag ID via environment variable.
  - Included a reference to the Quartz configuration documentation within the config file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->